### PR TITLE
Override region using AWS_REGION environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Or set the `AWS_PROFILE` environment variable and run `awsenv` without arguments
     export AWS_PROFILE=myprofile
     awsenv
 
+Can also optionally override the region by setting the `AWS_REGION` environment variable.
+
 The output will be a series of `export` (or `unset`) statements:
 
     export AWS_DEFAULT_REGION=us-west-2

--- a/awsenv/profile.py
+++ b/awsenv/profile.py
@@ -156,6 +156,12 @@ class AWSProfile(AWSSession):
                 aws_secret_access_key=self.session._credentials.secret_key,
                 aws_session_token=self.session._credentials.token,
             )
+
+        # Override with AWS_REGION environment variable
+        region_from_envvar = environ.get("AWS_REGION")
+        if region_from_envvar:
+            result.update(region=region_from_envvar)
+
         return result
 
     def to_envvars(self):

--- a/awsenv/tests/test_profile.py
+++ b/awsenv/tests/test_profile.py
@@ -135,3 +135,18 @@ def test_profile_with_role_arn():
             aws_profile.to_envvars().get("AWS_SESSION_NAME"),
             is_(equal_to(CACHED_SESSION.name)),
         )
+
+
+def test_profile_region_from_envvar():
+    """
+    Use AWS_REGION environment variable for region if set.
+    """
+    with custom_config(profile=PROFILE, role_arn=ROLE_ARN):
+        region = 'us-east-2'
+        environ['AWS_REGION'] = region
+        aws_profile = AWSProfile(
+            profile=PROFILE,
+            session_duration=DEFAULT_SESSION_DURATION,
+            cached_session=None,
+        )
+        assert_that(aws_profile.region_name, is_(equal_to(region)))


### PR DESCRIPTION
Allow users to set region using an environment variable.